### PR TITLE
Change in import statement

### DIFF
--- a/gitter.py
+++ b/gitter.py
@@ -1,4 +1,4 @@
-from errbot.errBot import ErrBot
+from errbot.core import ErrBot
 import json
 import logging
 import time


### PR DESCRIPTION
The ErrBot import statement is changed to
```
from errbot.core import ErrBot
```

Closes https://github.com/errbotio/err-backend-gitter/issues/35